### PR TITLE
Revert "add expired drink product"

### DIFF
--- a/static/products.yml
+++ b/static/products.yml
@@ -29,11 +29,6 @@
   event_price: 2.50
   currency: SCHWEPPES
   category: drink
-- name: Expired drink
-  price: 1
-  event_price: 1
-  currency: EXPIRED_DRINK
-  category: drink
 
 # weird german stuff
 - name: Fritz


### PR DESCRIPTION
Reverts 0x20/tab-data#16

`1` instead of `1.00` price may have broken the bar