### PR TITLE
Add mattermost notification bot

### DIFF
--- a/.github/workflows/mmbot.yml
+++ b/.github/workflows/mmbot.yml
@@ -1,0 +1,36 @@
+# This workflow will install Python dependencies and run a python script to send a Mattermost message
+# For more information see: https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-python
+
+name: Mattermost bot
+
+env:
+  MM_URL: https://chat.hackerspace.gent/
+  
+on:
+  push:
+    branches: [ "main" ]
+    paths: [ "ledger/*.beancount" ]
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v3
+      with:
+        fetch-depth: '2'
+    - name: Set up Python 3.10
+      uses: actions/setup-python@v4
+      with:
+        python-version: "3.10"
+        cache: 'pip'
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        if [ -f mmbot/requirements.txt ]; then pip install -r mmbot/requirements.txt; fi
+    - name: Run mmbot-tx.py
+      run: python mmbot/mmbot-tx.py ${{ env.MM_URL }} ${{ secrets.MMBOT_TOKEN }}

--- a/mmbot/README.md
+++ b/mmbot/README.md
@@ -1,0 +1,13 @@
+# Intro
+The goal of this script is to send a Mattermost message when a transaction is found for that user.
+
+You can subscribe to these messages by adding your Mattermost username (mm_username) to the file `static/members.beancount`
+
+Example:
+```
+1970-01-01 open Liabilities:Bar:Members:Gust
+  mm_name: "gust"
+```
+This script is called by the Github Actions `.github/workflows/mmbot.yml`. The Action will be triggered for every change in the `ledger/*.beancount` files and will search for the hard-coded commit message "`Automatic commit by backtab`" to assume it is a bar transaction commit.
+
+When a transaction is found the barbot Mattermost account will send a message to the user.

--- a/mmbot/mmbot-tx.py
+++ b/mmbot/mmbot-tx.py
@@ -1,0 +1,155 @@
+import sys
+import logging
+import subprocess
+import requests
+import json
+from pprint import pformat
+from beancount import loader
+
+
+class MattermostAPI:
+    def __init__(self, server_url, auth_token):
+        self.server_url = server_url
+        self.api_endpoint = "api/v4/"
+        self.auth_token = auth_token
+        self.headers = {
+            'Authorization': 'Bearer ' + auth_token,
+            'Content-Type': 'application/json'
+        }
+
+
+    def mm_view_self(self):
+        api_path = "users/me"
+        response = requests.get(self.server_url + self.api_endpoint + api_path, headers=self.headers)
+        if response.status_code == 200:
+            logging.debug('Response mm_view_self:\n %s', pformat(response.json()))
+            user = response.json()
+            return user['id']
+        else:
+            logging.error("Error mm_view_self: %s", response.text)
+
+
+    def mm_search_userid(self, user_name):
+        api_path = "users/search"
+        data = { "term": user_name }
+
+        response = requests.post(self.server_url + self.api_endpoint + api_path, headers=self.headers, data=json.dumps(data))
+        if response.status_code == 200:
+            logging.debug('Response mm_search_userid:\n %s', pformat(response.json()))            
+            user = response.json()
+            return user[0]['id']
+        else:
+            logging.error("Error mm_search_userid: %s", response.text)
+
+
+    def mm_get_channel_id(self,bot_id,tx_user_id):
+        api_path = "channels/direct"
+        data = [bot_id, tx_user_id]
+
+        response = requests.post(self.server_url + self.api_endpoint + api_path, headers=self.headers, data=json.dumps(data))
+        if response.status_code == 201:
+            logging.debug('Response mm_get_channel_id:\n %s', pformat(response.json()))
+            channel_id = response.json()
+            return channel_id['id']
+        else:
+            logging.error("Error mm_get_channel_id: %s", response.text)
+
+
+    def mm_direct_message(self, channel_id, msg):
+        api_path = "posts"
+        data = {
+            "channel_id": channel_id,
+            "message": msg
+        }
+        response = requests.post(self.server_url + self.api_endpoint + api_path, headers=self.headers, data=json.dumps(data))
+        if response.status_code == 201:
+            logging.info('Response mm_direct_message:\n %s', pformat(response.json()))
+        else:
+            logging.error("Error: Failed to post direct message. Status code: %s %s", response.status_code, response.text)
+
+
+def get_mm_user(user):
+    member_name = user
+    # Load the members data from the 'members.beancount' file
+    members_file = "./static/members.beancount"
+    with open(members_file, "r") as f:
+        members_data = f.read()
+    # Parse the members data using beancount
+    members_entries, _, _ = loader.load_string(members_data)
+    # Find and extract the mm_name for the target member
+    mm_name = None
+    for member_entry in members_entries:
+        logging.debug('Entry: %s', member_entry)
+        logging.debug('Account: %s', member_entry.account)
+        if (
+            member_entry.__class__.__name__ == "Open" and
+            member_entry.account == f"Liabilities:Bar:Members:{member_name}"
+        ):
+            mm_name = member_entry.meta.get("mm_name")
+            break
+
+    if mm_name:
+        logging.info('Mattermost user for %s is: %s', member_name, mm_name)
+        return mm_name
+    else:
+        logging.info('Mattermost user (mm_name) not found for %s in members.beancount. Stopping here.', member_name)
+        sys.exit()
+
+
+def get_user_from_tx(added_transactions):
+    # Parse the transaction using beancount
+    tx_entries, _, _ = loader.load_string(added_transactions)
+
+    # Extract the member name from the transaction description
+    transaction_description = tx_entries[0].narration
+    member_name = transaction_description.split(" ")[0]
+    return member_name
+
+
+def extract_added_transactions_from_git_show():
+    result = subprocess.run(['git', 'show'], stdout=subprocess.PIPE)
+    output = result.stdout.decode('utf-8')
+    lines = output.splitlines()
+    tx = ""
+    for line in lines:
+        if line.startswith('+'):
+            if line.startswith('++'):
+                continue
+            tx = tx + line.lstrip('+') + '\n'
+    return tx
+
+
+if __name__ == '__main__':
+    logging.basicConfig(format='[%(asctime)s] [%(levelname)s] %(message)s', level='INFO')
+    logging.info('Starting script %s', __file__)
+
+    # Hardcoded from github actions yml
+    mm_url = sys.argv[1]
+    token = sys.argv[2]
+
+    # Check if the commit is transaction 
+    result = subprocess.run(['git', 'log','-1','--format=%s'], stdout=subprocess.PIPE)
+    output = result.stdout.decode('utf-8').rstrip()
+    if output != "Automatic commit by backtab":
+        logging.info("Commit msg does not match 'Automatic commit by backtab', assuming not a transaction. Stopping here.")
+        sys.exit(0)
+
+    added_transactions = extract_added_transactions_from_git_show()
+    logging.info('Git commit msg:\n %s', added_transactions)
+    member_name = get_user_from_tx(added_transactions)
+    logging.info('Membername from transaction: %s', member_name)
+    mm_user = get_mm_user(member_name)
+
+    api = MattermostAPI(mm_url, token)
+    # Setup mattermost direct message channel between barbot and transaction user
+    barbot_user_id = api.mm_view_self()
+    logging.info('Barbot mm user_id: %s', barbot_user_id)
+    tx_user_id = api.mm_search_userid(mm_user)
+    logging.info('%s mm user_id: %s', mm_user, tx_user_id)
+    direct_channel_id = api.mm_get_channel_id(barbot_user_id, tx_user_id)
+    logging.info('Direct mm channel id: %s', direct_channel_id)
+    # Send mattermost msg
+    msg = "Bar transaction found for user " + member_name + ":\n" + added_transactions
+    api.mm_direct_message(direct_channel_id, msg)
+    
+    logging.info('Done.')

--- a/mmbot/requirements.txt
+++ b/mmbot/requirements.txt
@@ -1,0 +1,2 @@
+requests
+beancount == 2.3.5

--- a/static/members.beancount
+++ b/static/members.beancount
@@ -8,12 +8,14 @@
 1970-01-01 open Liabilities:Bar:Members:Bloemist
 1970-01-01 open Liabilities:Bar:Members:David
 1970-01-01 open Liabilities:Bar:Members:Els
+  mm_name: "betty"
 1970-01-01 open Liabilities:Bar:Members:Elvis
   display_name: "Evils"
 1970-01-01 open Liabilities:Bar:Members:Enzian
 1970-01-01 open Liabilities:Bar:Members:Ewaut
 1970-01-01 open Liabilities:Bar:Members:Folkaholic
 1970-01-01 open Liabilities:Bar:Members:Gust
+  mm_name: "gust"
 1970-01-01 open Liabilities:Bar:Members:Jens
 1970-01-01 open Liabilities:Bar:Members:Joren
 1970-01-01 open Liabilities:Bar:Members:Joris
@@ -38,10 +40,12 @@
   display_name: "Super​pumpie"
 1970-01-01 open Liabilities:Bar:Members:Thequux
   display_name: "TQ"
+  mm_name: "thequux"
 1970-01-01 open Liabilities:Bar:Members:Thijs
 1970-01-01 open Liabilities:Bar:Members:Thomas
 2018-10-25 open Liabilities:Bar:Members:Maja
   display_name: "Nachtvlinder"
+  mm_name: "nachtvlinder"
 2018-11-08 open Liabilities:Bar:Members:Manon
 2019-02-07 open Liabilities:Bar:Members:Yvan
   display_name: "Yvan"
@@ -49,6 +53,7 @@
   display_name: "MrProzakc"
 2019-06-09 open Liabilities:Bar:Members:Lisa
 2019-08-29 open Liabilities:Bar:Members:Miker
+  mm_name: "miker"
 2019-11-28 open Liabilities:Bar:Members:Carroarmato0
   display_name: "Carro​armato0"
 2019-11-28 open Liabilities:Bar:Members:Sven
@@ -57,6 +62,7 @@
   display_name: "Anton​Alstublieft"
 2019-11-28 open Liabilities:Bar:Members:B0Hr
 2020-07-29 open Liabilities:Bar:Members:Sander
+  mm_name: "sander"
 2020-12-30 open Liabilities:Bar:Members:Ljaytee
 2021-02-06 open Liabilities:Bar:Members:Jobj
 2021-02-20 open Liabilities:Bar:Members:Lonelycelt


### PR DESCRIPTION
The goal of this script is to send a Mattermost message when a transaction is found for that user.

You can subscribe to these messages by adding your Mattermost username (mm_username) to the file `static/members.beancount`

Example:
```
1970-01-01 open Liabilities:Bar:Members:Gust
  mm_name: "gust"
```
This script is called by the Github Actions `.github/workflows/mmbot.yml`. The Action will be triggered for every change in the `ledger/*.beancount` files and will search for the hard-coded commit message "`Automatic commit by backtab`" to assume it is a bar transaction commit.

When a transaction is found the barbot Mattermost account will send a message to the user.